### PR TITLE
fixes return values for pcall on sync_connect

### DIFF
--- a/websocket/client_async.lua
+++ b/websocket/client_async.lua
@@ -194,10 +194,11 @@ local new = function()
 				end
 				on_connected(ok, err)
 			else
-				local result, ok, err_or_protocol, headers = pcall(function()
-					return sync_connect(self, ws_url, ws_protocol, ssl_params)
+				local ok, err_or_protocol, headers
+				local pcall_ok, pcall_err = pcall(function()
+					ok, err_or_protocol, headers = sync_connect(self, ws_url, ws_protocol, ssl_params)
 				end)
-				on_connected(ok, err_or_protocol)
+				on_connected(pcall_ok and ok, pcall_err or err_or_protocol)
 			end
 			start_on_message_loop()
 		end)

--- a/websocket/client_async.lua
+++ b/websocket/client_async.lua
@@ -194,7 +194,7 @@ local new = function()
 				end
 				on_connected(ok, err)
 			else
-				local ok, err_or_protocol, headers = pcall(function()
+				local result, ok, err_or_protocol, headers = pcall(function()
 					return sync_connect(self, ws_url, ws_protocol, ssl_params)
 				end)
 				on_connected(ok, err_or_protocol)


### PR DESCRIPTION
This pull-request fixes triggering `on_connected` with `err` whenever a handshake error happened.

The previous behavior was that every connection was "successful", even though an handshake error might've happened.

The `sync_connect()` method returns 3 values, and `pcall` returns 4 values (the first one being if `pcall` call has runned)